### PR TITLE
Add support for x-craft-preview to allow previewing revisions

### DIFF
--- a/src/EventSubscriber/PreviewModeEventSubscriber.php
+++ b/src/EventSubscriber/PreviewModeEventSubscriber.php
@@ -54,7 +54,7 @@ class PreviewModeEventSubscriber implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        $craftPreview = $request->get('x-craft-live-preview');
+        $craftPreview = $request->get('x-craft-live-preview', $request->get('x-craft-preview'));
         $token = $request->get('token');
         if (!empty($craftPreview) && !empty($token)) {
             $this->previewMode = true;


### PR DESCRIPTION
Craft CMS recently [allowed to preview revisions](https://github.com/craftcms/cms/discussions/14521). Another header, `x-craft-preview`, is used for this.

This small PR allows Strata to retrieve those revisions as well.